### PR TITLE
add python.sh for uv tool installs

### DIFF
--- a/inc/bash/python.sh
+++ b/inc/bash/python.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+echo "==> Installing Python tools via uv..."
+
+uv tool install ipython
+uv tool install tbump
+uv tool install towncrier
+uv tool install pytest --with pytest-regressions
+
+echo "==> Done! Python tools installed."


### PR DESCRIPTION
## Summary
- Add `python.sh` script that installs Python tools via `uv tool install`: ipython, tbump, towncrier, pytest (with pytest-regressions plugin)

## Test plan
- [x] Ran script successfully on macOS

## Summary by Sourcery

New Features:
- Introduce a python.sh helper script to install ipython, tbump, towncrier, and pytest with the pytest-regressions plugin via uv.