### PR TITLE
Add pre-commit

### DIFF
--- a/inc/bash/brew.sh
+++ b/inc/bash/brew.sh
@@ -98,6 +98,7 @@ for i in \
   tokei \
   tree \
   vim \
+  weechat \
   wget \
   yarn \
   zoxide \

--- a/inc/bash/python.sh
+++ b/inc/bash/python.sh
@@ -2,6 +2,7 @@
 
 echo "==> Installing Python tools via uv..."
 
+uv tool install pre-commit
 uv tool install ipython
 uv tool install tbump
 uv tool install towncrier

--- a/inc/bash/weechat.sh
+++ b/inc/bash/weechat.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Install wee-slack for Slack in the terminal
+# https://github.com/wee-slack/wee-slack
+
+set -euo pipefail
+
+echo "==> Setting up wee-slack..."
+
+if ! command -v weechat &>/dev/null; then
+  echo "weechat not found. Install it first (brew install weechat)."
+  exit 1
+fi
+
+# Install Python dependency
+brew install python-websocket-client 2>/dev/null || python3 -m pip install --break-system-packages websocket-client
+
+echo "==> wee-slack dependencies installed!"
+echo ""
+echo "Next steps:"
+echo "  1. Run: weechat"
+echo "  2. Install the plugin:  /script install slack.py"
+echo "  3. Install notifications: /script install notification_center.py"
+echo "  4. Register workspace: /slack register"
+echo "  5. Follow the link to authorize, then paste the code back"
+echo "  6. Reload: /python reload slack"


### PR DESCRIPTION
## Summary
- Add `weechat` to brew packages
- Add `weechat.sh` script for setting up wee-slack (Slack in the terminal)
- Add `pre-commit` to uv Python tools

## Test plan
- [ ] Run `brew.sh` and verify weechat installs
- [ ] Run `weechat.sh` and verify wee-slack dependencies install
- [ ] Run `python.sh` and verify pre-commit installs via uv

## Summary by Sourcery

Add terminal Slack support and code quality tooling to the development environment.

New Features:
- Include weechat in Homebrew-installed CLI tools.
- Provide a weechat helper script to set up wee-slack for Slack integration in the terminal.
- Install pre-commit as a Python tool via uv.