### PR TITLE
Add declarative cross-platform app installation flow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,15 +20,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Install dependencies
-        run: |
-          make dev
-      - name: make docs
-        run: |
-          make docs
+        run: uv sync --extra docs --extra dev
+      - name: Build documentation
+        run: uv run jupyter-book build docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:

--- a/Justfile
+++ b/Justfile
@@ -4,11 +4,11 @@ uv:
 
 # Install dependencies
 install:
-    uv venv --python 3.11
+    uv venv --python 3.12
     uv sync --extra docs --extra dev
 
 dev:
-    pip install -e .[dev,docs]
+    uv sync --extra dev --extra docs
 
 # Install the inc command globally while keeping this checkout editable
 tool-install:
@@ -27,13 +27,13 @@ tool-uninstall:
     uv tool uninstall inc
 
 test:
-    pytest -s
+    uv run pytest -s
 
 cov:
-    pytest --cov=inc
+    uv run pytest --cov=inc
 
 mypy:
-    mypy . --ignore-missing-imports
+    uv run mypy . --ignore-missing-imports
 
 # Remove merged branches
 git-rm-merged:

--- a/Justfile
+++ b/Justfile
@@ -10,6 +10,22 @@ install:
 dev:
     pip install -e .[dev,docs]
 
+# Install the inc command globally while keeping this checkout editable
+tool-install:
+    uv tool install --editable . --python 3.12 --force
+
+# Verify the globally installed command works outside this repository
+tool-check:
+    cd /tmp && inc --help && inc ls
+
+# Add uv's executable directory to the shell PATH
+tool-path:
+    uv tool update-shell
+
+# Remove the globally installed inc command
+tool-uninstall:
+    uv tool uninstall inc
+
 test:
     pytest -s
 

--- a/Justfile
+++ b/Justfile
@@ -56,7 +56,7 @@ ssh:
     git push --set-upstream origin main
 
 docs:
-    uv run jb build docs
+    uv run jupyter-book build docs
 
 # Default target
 default:

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,6 @@ ssh:
 	git push --set-upstream origin main
 
 docs:
-	uv run jb build docs
+	uv run jupyter-book build docs
 
 .PHONY: drc doc docs

--- a/README.md
+++ b/README.md
@@ -56,6 +56,49 @@ To see what a script would do without running it:
 inc run gmsh --dry-run
 ```
 
+### Install applications
+
+Install an individual application with the native package manager:
+
+```bash
+inc apps install gh
+```
+
+For the same short workflow used by the script runner, catalog applications are
+also available through `inc run` and appear in its completion list:
+
+```bash
+inc run gh
+```
+
+App and profile names support shell completion after running
+`inc --install-completion`. For example, type `inc apps install g` and press Tab.
+
+Preview the command without installing anything:
+
+```bash
+inc apps install gh --dry-run
+```
+
+Install a predefined group of applications without confirmation:
+
+```bash
+inc apps install --profile core --yes
+inc apps install --profile dev --yes
+```
+
+Inspect the catalog and current installation state:
+
+```bash
+inc apps list
+inc apps status
+inc doctor
+```
+
+Applications and platform package mappings are declared in `inc/apps.toml`.
+The supported package families are Arch/Manjaro, Debian/Ubuntu, Fedora/RHEL,
+openSUSE, macOS/Homebrew, and Windows/WinGet.
+
 ### View script contents
 
 ```
@@ -67,6 +110,13 @@ inc cat <script_name>
 git clone https://github.com/joamatab/install_new_computer.git ~/install_new_computer
 cd ~/install_new_computer
 uv sync
+```
+
+Install the local checkout as an editable command that works from any directory:
+
+```bash
+just tool-install
+just tool-check
 ```
 
 For MacOs type this into a terminal first:

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -9,9 +9,15 @@ parts:
   #     - file: tutorial
   #       sections:
   #         - file: notebooks/demo
+  - caption: Guide
+    chapters:
+      - file: tutorial
+      - file: apps
   - caption: Reference
     chapters:
       - file: windows
+        sections:
+          - file: windows_extra
       - file: mac
       - file: linux
       - file: api

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -1,0 +1,160 @@
+# Install applications
+
+`inc` can install individual command-line applications with the native package
+manager for your operating system. Application names, executable checks, and
+package mappings live in `inc/apps.toml`, so the same command works across
+supported computers.
+
+## Discover applications
+
+Run `inc apps` to see the detected platform, available applications, package
+names, and whether each command is installed:
+
+```console
+$ inc apps
+Platform: arch
+Applications:
+  gh           missing   github-cli               GitHub CLI
+  git          installed git                      Git version control
+  curl         installed curl                     Command-line data transfer tool
+  ripgrep      installed ripgrep                  Fast recursive text search
+  fzf          installed fzf                      Command-line fuzzy finder
+  just         installed just                     Command runner for project recipes
+  shellcheck   missing   shellcheck               Shell script analyzer
+  node         installed nodejs                   Node.js JavaScript runtime
+Profiles:
+  core         gh, git, curl, ripgrep, fzf
+  dev          gh, git, curl, ripgrep, fzf, just, shellcheck, node
+```
+
+Check everything or only selected applications without changing the computer:
+
+```bash
+inc apps status
+inc apps status gh shellcheck
+```
+
+## Install an application
+
+Preview the native command first:
+
+```console
+$ inc apps install gh --dry-run
+gh: sudo pacman -S --needed --noconfirm github-cli
+```
+
+Then install it. `inc` asks for confirmation, invokes the native package
+manager, and verifies the resulting executable with `--version`:
+
+```bash
+inc apps install gh
+```
+
+Pass `--yes` or `-y` to skip the `inc` confirmation prompt:
+
+```bash
+inc apps install gh --yes
+```
+
+After installing GitHub CLI, `inc` prints the authentication step:
+
+```bash
+gh auth login
+```
+
+## Use the familiar `inc run` flow
+
+Catalog applications also appear alongside scripts in `inc ls` and the
+`inc run` completion list. This keeps the original short workflow:
+
+```bash
+inc run gh --dry-run
+inc run gh
+inc run gh --yes
+```
+
+If a shell script and catalog application have the same name, the existing
+shell script takes precedence.
+
+## Install a profile
+
+Profiles install a useful group of applications. Already-installed commands
+are skipped automatically, and duplicate entries are removed:
+
+```bash
+inc apps install --profile core
+inc apps install --profile dev --yes
+```
+
+The included profiles are:
+
+| Profile | Applications |
+| --- | --- |
+| `core` | `gh`, `git`, `curl`, `ripgrep`, `fzf` |
+| `dev` | core apps plus `just`, `shellcheck`, and `node` |
+
+## Shell completion
+
+Install completion once, then restart the shell:
+
+```bash
+inc --install-completion
+```
+
+Application and profile names can then be completed with Tab:
+
+```text
+inc run g<Tab>
+inc apps install g<Tab>
+inc apps status sh<Tab>
+inc apps install --profile d<Tab>
+```
+
+## Supported package managers
+
+| Platform family | Package manager |
+| --- | --- |
+| Arch and Manjaro | `pacman` |
+| Debian and Ubuntu | `apt-get` |
+| Fedora, RHEL, and CentOS | `dnf` |
+| openSUSE | `zypper` |
+| macOS | Homebrew |
+| Windows | WinGet |
+
+Run `inc doctor` to check catalog loading, platform detection, the native
+package manager, the global `inc` command, and GitHub authentication when `gh`
+is present.
+
+## Add an application
+
+Add a section to `inc/apps.toml`. The `command` is the executable used for
+status and post-install verification; platform fields are native package names:
+
+```toml
+[apps.example]
+description = "Example command-line application"
+command = "example"
+arch = "example"
+debian = "example"
+fedora = "example"
+opensuse = "example"
+macos = "example"
+windows = "Publisher.Example"
+post_install = ["example", "configure"]
+```
+
+Platform fields may be omitted when an application is not supported there.
+Add the application name to a list under `[profiles]` if it belongs in a
+profile. Catalog validation rejects profiles that refer to unknown apps.
+
+## Test a development checkout globally
+
+Install this checkout in editable mode so changes are immediately visible from
+other directories and terminal tabs:
+
+```bash
+just tool-install
+just tool-check
+```
+
+Remove it later with `just tool-uninstall`.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,3 +1,67 @@
 
-```{tableofcontents}
+# Getting started
+
+## Install `inc`
+
+Install [uv](https://docs.astral.sh/uv/) and use it to install the released
+command in an isolated environment:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+uv tool install inc --python 3.12
+```
+
+Confirm that the command is available:
+
+```bash
+inc --help
+inc doctor
+```
+
+## Explore the available actions
+
+`inc ls` shows both the original setup scripts and applications from the new
+cross-platform catalog:
+
+```bash
+inc ls
+```
+
+Inspect a script before running it:
+
+```bash
+inc cat gmsh
+inc run gmsh --dry-run
+```
+
+Inspect and preview catalog applications in the same way:
+
+```bash
+inc apps
+inc run gh --dry-run
+```
+
+See {doc}`apps` for application profiles, supported package managers, shell
+completion, and instructions for extending the catalog.
+
+## Develop `inc`
+
+Clone the repository and install the checkout as an editable global tool:
+
+```bash
+git clone https://github.com/joamatab/install_new_computer.git
+cd install_new_computer
+uv sync --extra dev --extra docs
+uv tool install --editable . --python 3.12 --force
+```
+
+Changes under `inc/` are then visible immediately when running `inc` from a
+different directory or terminal tab.
+
+Run the checks and build the documentation with:
+
+```bash
+uv run pytest
+uv run pre-commit run --all-files
+uv run jupyter-book build docs
 ```

--- a/inc/app.py
+++ b/inc/app.py
@@ -7,20 +7,28 @@ from pathlib import Path
 
 import typer
 
+from .apps import apps_app, complete_app, doctor, load_catalog
+from .apps import install as install_apps
 from .config import PATH
 
 app = typer.Typer()
+app.add_typer(apps_app, name="apps")
+app.command()(doctor)
 
 
 def complete_script(incomplete: str) -> list[str]:
-    """Return matching bash script names for autocompletion."""
+    """Return matching script and application names for autocompletion."""
     bash_dir = PATH.bash
-    if not bash_dir.exists():
-        return []
-    scripts = sorted(
-        str(f.relative_to(bash_dir)).removesuffix(".sh") for f in bash_dir.rglob("*.sh")
+    scripts = (
+        {
+            str(f.relative_to(bash_dir)).removesuffix(".sh")
+            for f in bash_dir.rglob("*.sh")
+        }
+        if bash_dir.exists()
+        else set()
     )
-    return [s for s in scripts if s.startswith(incomplete)]
+    matches = scripts | set(complete_app(incomplete))
+    return sorted(name for name in matches if name.startswith(incomplete))
 
 
 @app.command()
@@ -169,7 +177,7 @@ def ls(
         False, "-r", help="List scripts in subdirectories too"
     ),
 ):
-    """List all available bash scripts."""
+    """List available scripts and catalog applications."""
     bash_dir = PATH.bash
     if not bash_dir.exists():
         print("Bash directory not found.")
@@ -193,12 +201,16 @@ def ls(
     for script in scripts:
         print(f"  {script}")
 
+    print("Available applications:")
+    for name in load_catalog().apps:
+        print(f"  {name}")
+
 
 @app.command()
 def run(
     script: str = typer.Argument(
         ...,
-        help="Name of the bash script to run (without .sh extension). Use / for subdirectories (e.g. electronics/klayout/install_mac)",
+        help="Script or catalog application name. Use / for script subdirectories.",
         autocompletion=complete_script,
     ),
     args: list[str] | None = typer.Argument(
@@ -208,13 +220,29 @@ def run(
         False, help="Print the command that would be executed without running it"
     ),
 ):
-    """Run a bash script from the bash/ directory."""
+    """Run a bash script or install a catalog application."""
     bash_dir = PATH.bash
     script_path = bash_dir / f"{script}.sh"
 
     if not script_path.exists():
+        if script in load_catalog().apps:
+            app_args = args or []
+            unsupported_args = [arg for arg in app_args if arg not in {"--yes", "-y"}]
+            if unsupported_args:
+                print(
+                    "Application installs only accept --yes/-y through 'inc run'. "
+                    "Use 'inc apps install' for other options."
+                )
+                raise typer.Exit(2)
+            install_apps(
+                names=[script],
+                profile=None,
+                dry_run=dry_run,
+                yes=bool({"--yes", "-y"} & set(app_args)),
+            )
+            return
         print(f"Script '{script}.sh' not found in bash directory.")
-        print("Use 'inc ls' or 'inc ls -r' to see available scripts.")
+        print("Use 'inc ls' or 'inc ls -r' to see available scripts and applications.")
         return
 
     # Build the command

--- a/inc/apps.py
+++ b/inc/apps.py
@@ -1,0 +1,365 @@
+"""Declarative, cross-platform application installation."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import typer
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
+    import tomli as tomllib
+
+
+CATALOG_PATH = Path(__file__).with_name("apps.toml")
+SUPPORTED_PLATFORMS = ("arch", "debian", "fedora", "opensuse", "macos", "windows")
+
+apps_app = typer.Typer(
+    help="Install and inspect applications from the app catalog.",
+    invoke_without_command=True,
+)
+
+
+@dataclass(frozen=True)
+class AppDefinition:
+    """One application and its platform-specific package names."""
+
+    name: str
+    description: str
+    command: str
+    packages: dict[str, str]
+    post_install: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class Catalog:
+    """Applications and named groups loaded from the TOML catalog."""
+
+    apps: dict[str, AppDefinition]
+    profiles: dict[str, tuple[str, ...]]
+
+
+def load_catalog(path: Path = CATALOG_PATH) -> Catalog:
+    """Load and validate the application catalog."""
+    with path.open("rb") as file:
+        data: dict[str, Any] = tomllib.load(file)
+
+    apps = {}
+    for name, values in data.get("apps", {}).items():
+        packages = {
+            platform: values[platform]
+            for platform in SUPPORTED_PLATFORMS
+            if platform in values
+        }
+        apps[name] = AppDefinition(
+            name=name,
+            description=values.get("description", ""),
+            command=values.get("command", name),
+            packages=packages,
+            post_install=tuple(values.get("post_install", [])),
+        )
+
+    profiles = {
+        name: tuple(app_names) for name, app_names in data.get("profiles", {}).items()
+    }
+    unknown = {
+        app_name
+        for app_names in profiles.values()
+        for app_name in app_names
+        if app_name not in apps
+    }
+    if unknown:
+        raise ValueError(f"Unknown apps in profiles: {', '.join(sorted(unknown))}")
+    return Catalog(apps=apps, profiles=profiles)
+
+
+def complete_app(incomplete: str) -> list[str]:
+    """Return catalog app names matching the current shell input."""
+    return [name for name in load_catalog().apps if name.startswith(incomplete)]
+
+
+def complete_profile(incomplete: str) -> list[str]:
+    """Return profile names matching the current shell input."""
+    return [name for name in load_catalog().profiles if name.startswith(incomplete)]
+
+
+def _linux_ids(os_release: Path = Path("/etc/os-release")) -> set[str]:
+    """Return normalized Linux distribution identifiers."""
+    values: dict[str, str] = {}
+    try:
+        for line in os_release.read_text().splitlines():
+            if "=" in line:
+                key, value = line.split("=", 1)
+                values[key] = value.strip().strip('"').lower()
+    except OSError:
+        return set()
+    return {values.get("ID", ""), *values.get("ID_LIKE", "").split()} - {""}
+
+
+def detect_platform() -> str:
+    """Detect the package family used by this operating system."""
+    if sys.platform == "darwin":
+        return "macos"
+    if os.name == "nt" or sys.platform == "win32":
+        return "windows"
+    if sys.platform.startswith("linux"):
+        linux_ids = _linux_ids()
+        families = (
+            ("arch", {"arch", "manjaro"}),
+            ("debian", {"debian", "ubuntu", "linuxmint", "pop"}),
+            ("fedora", {"fedora", "rhel", "centos"}),
+            ("opensuse", {"opensuse", "suse"}),
+        )
+        for family, names in families:
+            if linux_ids & names:
+                return family
+    raise RuntimeError(f"Unsupported operating system: {sys.platform}")
+
+
+def install_command(platform: str, package: str) -> list[str]:
+    """Build the native package-manager command for a package."""
+    commands = {
+        "arch": ["sudo", "pacman", "-S", "--needed", "--noconfirm", package],
+        "debian": ["sudo", "apt-get", "install", "-y", package],
+        "fedora": ["sudo", "dnf", "install", "-y", package],
+        "opensuse": ["sudo", "zypper", "--non-interactive", "install", package],
+        "macos": ["brew", "install", package],
+        "windows": [
+            "winget",
+            "install",
+            "--id",
+            package,
+            "--exact",
+            "--accept-package-agreements",
+            "--accept-source-agreements",
+        ],
+    }
+    try:
+        return commands[platform]
+    except KeyError as error:
+        raise RuntimeError(f"Unsupported package platform: {platform}") from error
+
+
+def package_manager(platform: str) -> str:
+    """Return the executable required for a platform."""
+    return {
+        "arch": "pacman",
+        "debian": "apt-get",
+        "fedora": "dnf",
+        "opensuse": "zypper",
+        "macos": "brew",
+        "windows": "winget",
+    }[platform]
+
+
+def resolve_apps(
+    catalog: Catalog, names: list[str], profile: str | None
+) -> list[AppDefinition]:
+    """Resolve app names and a profile to unique app definitions."""
+    requested = list(names)
+    if profile:
+        if profile not in catalog.profiles:
+            choices = ", ".join(sorted(catalog.profiles))
+            raise ValueError(
+                f"Unknown profile '{profile}'. Available profiles: {choices}"
+            )
+        requested.extend(catalog.profiles[profile])
+    if not requested:
+        raise ValueError("Provide one or more app names or use --profile.")
+
+    unknown = sorted(set(requested) - catalog.apps.keys())
+    if unknown:
+        raise ValueError(f"Unknown apps: {', '.join(unknown)}")
+    return [catalog.apps[name] for name in dict.fromkeys(requested)]
+
+
+def _installed(app: AppDefinition) -> bool:
+    return shutil.which(app.command) is not None
+
+
+def verify_app(app: AppDefinition) -> tuple[bool, str]:
+    """Run a lightweight version check after installation."""
+    try:
+        result = subprocess.run(
+            [app.command, "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return False, f"'{app.command}' is not on PATH"
+    output = (result.stdout or result.stderr).strip().splitlines()
+    detail = output[0] if output else f"exit code {result.returncode}"
+    return result.returncode == 0, detail
+
+
+@apps_app.command("list")
+def list_apps() -> None:
+    """List available applications and profiles."""
+    catalog = load_catalog()
+    platform = detect_platform()
+    typer.echo(f"Platform: {platform}")
+    typer.echo("Applications:")
+    for item in catalog.apps.values():
+        package = item.packages.get(platform, "unsupported")
+        state = "installed" if _installed(item) else "missing"
+        typer.echo(f"  {item.name:<12} {state:<9} {package:<24} {item.description}")
+    typer.echo("Profiles:")
+    for name, members in catalog.profiles.items():
+        typer.echo(f"  {name:<12} {', '.join(members)}")
+
+
+@apps_app.callback()
+def apps_default(ctx: typer.Context) -> None:
+    """Show the application catalog when no subcommand is given."""
+    if ctx.invoked_subcommand is None:
+        list_apps()
+
+
+@apps_app.command()
+def status(
+    names: list[str] | None = typer.Argument(None, autocompletion=complete_app),
+) -> None:
+    """Show whether catalog applications are installed."""
+    catalog = load_catalog()
+    try:
+        selected = (
+            resolve_apps(catalog, names or [], None)
+            if names
+            else list(catalog.apps.values())
+        )
+    except ValueError as error:
+        typer.echo(f"Error: {error}", err=True)
+        raise typer.Exit(2) from error
+    for item in selected:
+        state = "installed" if _installed(item) else "missing"
+        typer.echo(f"{item.name}: {state}")
+
+
+@apps_app.command()
+def install(
+    names: list[str] | None = typer.Argument(
+        None, help="Applications to install", autocompletion=complete_app
+    ),
+    profile: str | None = typer.Option(
+        None, help="Install a named profile", autocompletion=complete_profile
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Print commands only"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
+) -> None:
+    """Install applications using the native package manager."""
+    catalog = load_catalog()
+    try:
+        selected = resolve_apps(catalog, names or [], profile)
+        platform = detect_platform()
+    except (RuntimeError, ValueError) as error:
+        typer.echo(f"Error: {error}", err=True)
+        raise typer.Exit(2) from error
+
+    pending = [item for item in selected if not _installed(item)]
+    for item in selected:
+        if item not in pending:
+            typer.echo(f"Already installed: {item.name}")
+    if not pending:
+        typer.echo("Everything requested is already installed.")
+        return
+
+    unsupported = [item.name for item in pending if platform not in item.packages]
+    if unsupported:
+        typer.echo(
+            f"Error: unsupported on {platform}: {', '.join(unsupported)}", err=True
+        )
+        raise typer.Exit(2)
+
+    commands = [install_command(platform, item.packages[platform]) for item in pending]
+    for item, command in zip(pending, commands):
+        typer.echo(f"{item.name}: {shlex.join(command)}")
+    if dry_run:
+        return
+
+    manager = package_manager(platform)
+    if shutil.which(manager) is None:
+        typer.echo(
+            f"Error: required package manager '{manager}' was not found.", err=True
+        )
+        raise typer.Exit(2)
+    if not yes and not typer.confirm(f"Install {len(pending)} application(s)?"):
+        typer.echo("Cancelled.")
+        raise typer.Abort()
+
+    failures = []
+    for item, command in zip(pending, commands):
+        typer.echo(f"Installing {item.name}...")
+        result = subprocess.run(command, check=False)
+        if result.returncode != 0:
+            failures.append(item.name)
+            typer.echo(f"Failed: {item.name}", err=True)
+            continue
+        verified, detail = verify_app(item)
+        if verified:
+            typer.echo(f"Verified: {item.name} ({detail})")
+        else:
+            failures.append(item.name)
+            typer.echo(f"Verification failed: {item.name} ({detail})", err=True)
+            continue
+        if item.post_install:
+            typer.echo(f"Next: {shlex.join(item.post_install)}")
+
+    if failures:
+        typer.echo(f"Failed applications: {', '.join(failures)}", err=True)
+        raise typer.Exit(1)
+
+
+def doctor() -> None:
+    """Check platform, package-manager, catalog, and PATH readiness."""
+    problems = 0
+    try:
+        catalog = load_catalog()
+        typer.echo(
+            f"Catalog: ok ({len(catalog.apps)} apps, {len(catalog.profiles)} profiles)"
+        )
+    except (OSError, ValueError) as error:
+        typer.echo(f"Catalog: error ({error})")
+        raise typer.Exit(1) from error
+
+    try:
+        platform = detect_platform()
+        typer.echo(f"Platform: {platform}")
+        manager = package_manager(platform)
+        if shutil.which(manager):
+            typer.echo(f"Package manager: {manager} (found)")
+        else:
+            problems += 1
+            typer.echo(f"Package manager: {manager} (missing)")
+    except RuntimeError as error:
+        problems += 1
+        typer.echo(f"Platform: error ({error})")
+
+    inc_path = shutil.which("inc")
+    if inc_path:
+        typer.echo(f"Global command: {inc_path}")
+    else:
+        problems += 1
+        typer.echo("Global command: missing (run 'just tool-install')")
+
+    if shutil.which("gh"):
+        auth = subprocess.run(
+            ["gh", "auth", "status"], check=False, capture_output=True, text=True
+        )
+        if auth.returncode == 0:
+            typer.echo("GitHub authentication: ready")
+        else:
+            problems += 1
+            typer.echo("GitHub authentication: needed (run 'gh auth login')")
+
+    if problems:
+        raise typer.Exit(1)
+    typer.echo("Everything looks ready.")

--- a/inc/apps.toml
+++ b/inc/apps.toml
@@ -1,0 +1,84 @@
+[apps.gh]
+description = "GitHub CLI"
+command = "gh"
+arch = "github-cli"
+debian = "gh"
+fedora = "gh"
+opensuse = "gh"
+macos = "gh"
+windows = "GitHub.cli"
+post_install = ["gh", "auth", "login"]
+
+[apps.git]
+description = "Git version control"
+command = "git"
+arch = "git"
+debian = "git"
+fedora = "git"
+opensuse = "git"
+macos = "git"
+windows = "Git.Git"
+
+[apps.curl]
+description = "Command-line data transfer tool"
+command = "curl"
+arch = "curl"
+debian = "curl"
+fedora = "curl"
+opensuse = "curl"
+macos = "curl"
+windows = "cURL.cURL"
+
+[apps.ripgrep]
+description = "Fast recursive text search"
+command = "rg"
+arch = "ripgrep"
+debian = "ripgrep"
+fedora = "ripgrep"
+opensuse = "ripgrep"
+macos = "ripgrep"
+windows = "BurntSushi.ripgrep.MSVC"
+
+[apps.fzf]
+description = "Command-line fuzzy finder"
+command = "fzf"
+arch = "fzf"
+debian = "fzf"
+fedora = "fzf"
+opensuse = "fzf"
+macos = "fzf"
+windows = "junegunn.fzf"
+
+[apps.just]
+description = "Command runner for project recipes"
+command = "just"
+arch = "just"
+debian = "just"
+fedora = "just"
+opensuse = "just"
+macos = "just"
+windows = "Casey.Just"
+
+[apps.shellcheck]
+description = "Shell script analyzer"
+command = "shellcheck"
+arch = "shellcheck"
+debian = "shellcheck"
+fedora = "ShellCheck"
+opensuse = "ShellCheck"
+macos = "shellcheck"
+windows = "koalaman.shellcheck"
+
+[apps.node]
+description = "Node.js JavaScript runtime"
+command = "node"
+arch = "nodejs"
+debian = "nodejs"
+fedora = "nodejs"
+opensuse = "nodejs"
+macos = "node"
+windows = "OpenJS.NodeJS.LTS"
+
+[profiles]
+core = ["gh", "git", "curl", "ripgrep", "fzf"]
+dev = ["gh", "git", "curl", "ripgrep", "fzf", "just", "shellcheck", "node"]

--- a/inc/apps.toml
+++ b/inc/apps.toml
@@ -1,83 +1,83 @@
-[apps.gh]
-description = "GitHub CLI"
-command = "gh"
-arch = "github-cli"
-debian = "gh"
-fedora = "gh"
-opensuse = "gh"
-macos = "gh"
-windows = "GitHub.cli"
-post_install = ["gh", "auth", "login"]
-
-[apps.git]
-description = "Git version control"
-command = "git"
-arch = "git"
-debian = "git"
-fedora = "git"
-opensuse = "git"
-macos = "git"
-windows = "Git.Git"
-
 [apps.curl]
-description = "Command-line data transfer tool"
-command = "curl"
 arch = "curl"
+command = "curl"
 debian = "curl"
+description = "Command-line data transfer tool"
 fedora = "curl"
-opensuse = "curl"
 macos = "curl"
+opensuse = "curl"
 windows = "cURL.cURL"
 
-[apps.ripgrep]
-description = "Fast recursive text search"
-command = "rg"
-arch = "ripgrep"
-debian = "ripgrep"
-fedora = "ripgrep"
-opensuse = "ripgrep"
-macos = "ripgrep"
-windows = "BurntSushi.ripgrep.MSVC"
-
 [apps.fzf]
-description = "Command-line fuzzy finder"
-command = "fzf"
 arch = "fzf"
+command = "fzf"
 debian = "fzf"
+description = "Command-line fuzzy finder"
 fedora = "fzf"
-opensuse = "fzf"
 macos = "fzf"
+opensuse = "fzf"
 windows = "junegunn.fzf"
 
+[apps.gh]
+arch = "github-cli"
+command = "gh"
+debian = "gh"
+description = "GitHub CLI"
+fedora = "gh"
+macos = "gh"
+opensuse = "gh"
+post_install = ["gh", "auth", "login"]
+windows = "GitHub.cli"
+
+[apps.git]
+arch = "git"
+command = "git"
+debian = "git"
+description = "Git version control"
+fedora = "git"
+macos = "git"
+opensuse = "git"
+windows = "Git.Git"
+
 [apps.just]
-description = "Command runner for project recipes"
-command = "just"
 arch = "just"
+command = "just"
 debian = "just"
+description = "Command runner for project recipes"
 fedora = "just"
-opensuse = "just"
 macos = "just"
+opensuse = "just"
 windows = "Casey.Just"
 
-[apps.shellcheck]
-description = "Shell script analyzer"
-command = "shellcheck"
-arch = "shellcheck"
-debian = "shellcheck"
-fedora = "ShellCheck"
-opensuse = "ShellCheck"
-macos = "shellcheck"
-windows = "koalaman.shellcheck"
-
 [apps.node]
-description = "Node.js JavaScript runtime"
-command = "node"
 arch = "nodejs"
+command = "node"
 debian = "nodejs"
+description = "Node.js JavaScript runtime"
 fedora = "nodejs"
-opensuse = "nodejs"
 macos = "node"
+opensuse = "nodejs"
 windows = "OpenJS.NodeJS.LTS"
+
+[apps.ripgrep]
+arch = "ripgrep"
+command = "rg"
+debian = "ripgrep"
+description = "Fast recursive text search"
+fedora = "ripgrep"
+macos = "ripgrep"
+opensuse = "ripgrep"
+windows = "BurntSushi.ripgrep.MSVC"
+
+[apps.shellcheck]
+arch = "shellcheck"
+command = "shellcheck"
+debian = "shellcheck"
+description = "Shell script analyzer"
+fedora = "ShellCheck"
+macos = "shellcheck"
+opensuse = "ShellCheck"
+windows = "koalaman.shellcheck"
 
 [profiles]
 core = ["gh", "git", "curl", "ripgrep", "fzf"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
+  "tomli; python_version < '3.11'",
   "typer"
 ]
 description = "install new computer"
@@ -24,15 +25,17 @@ keywords = ["python"]
 license = {file = "LICENSE"}
 name = "inc"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 version = "0.1.13"
 
 [project.optional-dependencies]
 dev = [
+  "mypy",
   "pre-commit",
   "pytest",
   "pytest-cov",
-  "pytest_regressions"
+  "pytest_regressions",
+  "ruff"
 ]
 docs = [
   "autodoc_pydantic",
@@ -63,8 +66,8 @@ strict = true
 # addopts = --tb=no
 addopts = '--tb=short'
 norecursedirs = ["extra/*.py"]
-python_files = ["inc/*.py", "notebooks/*.ipynb", "tests/*.py"]
-testpaths = ["inc/", "tests"]
+python_files = ["test_*.py"]
+testpaths = ["tests"]
 
 [tool.ruff]
 extend-exclude = ['bash/*']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dev = [
 ]
 docs = [
   "autodoc_pydantic",
-  "jupyter-book>=0.15.1,<2.2"
+  "jupyter-book>=0.15.1,<2"
 ]
 maintainer = [
   'tbump',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,17 @@
+from types import SimpleNamespace
+
 from typer.testing import CliRunner
 
 from inc import app
+from inc.apps import (
+    complete_app,
+    complete_profile,
+    detect_platform,
+    install_command,
+    load_catalog,
+    resolve_apps,
+    verify_app,
+)
 
 runner = CliRunner()
 
@@ -9,6 +20,8 @@ def test_ls():
     result = runner.invoke(app, ["ls"])
     assert result.exit_code == 0
     assert "Available bash scripts:" in result.stdout
+    assert "Available applications:" in result.stdout
+    assert "  gh" in result.stdout
 
 
 def test_ls_recursive():
@@ -41,7 +54,146 @@ def test_run_missing_script():
     assert "not found" in result.stdout
 
 
+def test_run_app_dry_run(monkeypatch):
+    monkeypatch.setattr("inc.apps.detect_platform", lambda: "arch")
+    monkeypatch.setattr("inc.apps.shutil.which", lambda command: None)
+
+    result = runner.invoke(app, ["run", "gh", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "sudo pacman -S --needed --noconfirm github-cli" in result.stdout
+
+
+def test_run_completion_includes_catalog_apps():
+    from inc.app import complete_script
+
+    assert "gh" in complete_script("gh")
+
+
 def test_version():
     from inc import __version__
 
     assert __version__
+
+
+def test_apps_list(monkeypatch):
+    monkeypatch.setattr("inc.apps.detect_platform", lambda: "arch")
+    monkeypatch.setattr("inc.apps.shutil.which", lambda command: None)
+
+    result = runner.invoke(app, ["apps", "list"])
+
+    assert result.exit_code == 0
+    assert "Platform: arch" in result.stdout
+    assert "gh" in result.stdout
+    assert "github-cli" in result.stdout
+    assert "Profiles:" in result.stdout
+
+
+def test_apps_without_subcommand_lists_catalog(monkeypatch):
+    monkeypatch.setattr("inc.apps.detect_platform", lambda: "arch")
+    monkeypatch.setattr("inc.apps.shutil.which", lambda command: None)
+
+    result = runner.invoke(app, ["apps"])
+
+    assert result.exit_code == 0
+    assert "Applications:" in result.stdout
+    assert "github-cli" in result.stdout
+
+
+def test_apps_install_dry_run(monkeypatch):
+    monkeypatch.setattr("inc.apps.detect_platform", lambda: "arch")
+    monkeypatch.setattr("inc.apps.shutil.which", lambda command: None)
+
+    result = runner.invoke(app, ["apps", "install", "gh", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "sudo pacman -S --needed --noconfirm github-cli" in result.stdout
+
+
+def test_apps_install_profile_deduplicates(monkeypatch):
+    monkeypatch.setattr("inc.apps.detect_platform", lambda: "arch")
+    monkeypatch.setattr("inc.apps.shutil.which", lambda command: None)
+
+    result = runner.invoke(
+        app, ["apps", "install", "gh", "--profile", "core", "--dry-run"]
+    )
+
+    assert result.exit_code == 0
+    assert result.stdout.count("gh: sudo pacman") == 1
+    assert "ripgrep: sudo pacman" in result.stdout
+
+
+def test_apps_install_failure_returns_nonzero(monkeypatch):
+    monkeypatch.setattr("inc.apps.detect_platform", lambda: "arch")
+    monkeypatch.setattr(
+        "inc.apps.shutil.which",
+        lambda command: "/usr/bin/pacman" if command == "pacman" else None,
+    )
+    monkeypatch.setattr(
+        "inc.apps.subprocess.run", lambda *args, **kwargs: SimpleNamespace(returncode=1)
+    )
+
+    result = runner.invoke(app, ["apps", "install", "gh", "--yes"])
+
+    assert result.exit_code == 1
+    assert "Failed applications: gh" in result.output
+
+
+def test_unknown_app_returns_usage_error():
+    result = runner.invoke(app, ["apps", "install", "not-in-catalog", "--dry-run"])
+
+    assert result.exit_code == 2
+    assert "Unknown apps: not-in-catalog" in result.output
+
+
+def test_resolve_profile():
+    catalog = load_catalog()
+
+    resolved = resolve_apps(catalog, [], "core")
+
+    assert [item.name for item in resolved] == ["gh", "git", "curl", "ripgrep", "fzf"]
+
+
+def test_detect_manjaro_as_arch(monkeypatch):
+    monkeypatch.setattr("inc.apps.sys.platform", "linux")
+    monkeypatch.setattr("inc.apps._linux_ids", lambda: {"manjaro", "arch"})
+
+    assert detect_platform() == "arch"
+
+
+def test_install_command_does_not_use_shell():
+    assert install_command("arch", "github-cli") == [
+        "sudo",
+        "pacman",
+        "-S",
+        "--needed",
+        "--noconfirm",
+        "github-cli",
+    ]
+
+
+def test_verify_app_runs_version_command(monkeypatch):
+    catalog = load_catalog()
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        return SimpleNamespace(returncode=0, stdout="gh version 2.0\n", stderr="")
+
+    monkeypatch.setattr("inc.apps.subprocess.run", fake_run)
+
+    verified, detail = verify_app(catalog.apps["gh"])
+
+    assert verified is True
+    assert detail == "gh version 2.0"
+    assert calls == [["gh", "--version"]]
+
+
+def test_app_name_completion():
+    assert complete_app("g") == ["gh", "git"]
+    assert complete_app("shell") == ["shellcheck"]
+
+
+def test_profile_completion():
+    assert complete_profile("c") == ["core"]
+    assert complete_profile("d") == ["dev"]


### PR DESCRIPTION
## Summary

- add a TOML application catalog with native package mappings for Arch/Manjaro, Debian/Ubuntu, Fedora/RHEL, openSUSE, macOS, and Windows
- add `inc apps` list, status, and install flows with profiles, confirmation, dry-run support, verification, and actionable failures
- expose catalog apps through the existing `inc ls` and `inc run` workflow, including shell completion
- add `inc doctor` checks and editable-development Just recipes
- document the new workflow and align development dependencies and test discovery

## Examples

`inc apps`
`inc apps install gh --dry-run`
`inc apps install --profile dev --yes`
`inc run gh`

## Validation

- `uv run pytest -q` (21 passed)
- `uv run ruff check inc/apps.py inc/app.py tests/test_cli.py`
- `uv run ruff format --check inc/apps.py inc/app.py tests/test_cli.py`
- `uv run mypy inc/apps.py --ignore-missing-imports`
- `uv build`

## Summary by Sourcery

Introduce a declarative, cross-platform application catalog and integrate it into the inc CLI for installing and inspecting apps alongside existing scripts.

New Features:
- Add a TOML-based application catalog with platform-specific package mappings for Arch/Manjaro, Debian/Ubuntu, Fedora/RHEL, openSUSE, macOS, and Windows.
- Expose new inc apps subcommands for listing, checking status, and installing catalog applications, including profile-based grouped installs and dry-run/confirmation flows.
- Integrate catalog applications into the existing inc run and inc ls commands, enabling unified listing, installation, and shell completion for scripts and apps.
- Add an inc doctor command to verify platform support, package-manager availability, global inc installation, and GitHub authentication readiness.

Enhancements:
- Extend shell completion and CLI help to cover catalog applications and profiles, and enhance error handling around unknown apps, profiles, and unsupported platforms.
- Update development tooling recipes to install inc as a globally available editable tool and add helper commands for checking, updating PATH, and uninstalling.
- Raise the minimum supported Python version to 3.10, add tomli/tomllib handling for TOML parsing, and refine pytest configuration and test discovery to focus on tests/.

Documentation:
- Expand README documentation with examples and guidance for the new application installation workflow, catalog structure, profiles, and development helper commands.

Tests:
- Add comprehensive CLI and catalog tests covering app listing, status, installation flows, profile resolution and deduplication, platform detection, verification behavior, and shell completion.