### PR TITLE
Configure SSH server on Arch

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -10,6 +10,22 @@ install:
 dev:
     pip install -e .[dev,docs]
 
+# Install the inc command globally while keeping this checkout editable
+tool-install:
+    uv tool install --editable . --python 3.12 --force
+
+# Verify the globally installed command works outside this repository
+tool-check:
+    cd /tmp && inc --help && inc ls
+
+# Add uv's executable directory to the shell PATH
+tool-path:
+    uv tool update-shell
+
+# Remove the globally installed inc command
+tool-uninstall:
+    uv tool uninstall inc
+
 test:
     pytest -s
 

--- a/inc/bash/sshserver.sh
+++ b/inc/bash/sshserver.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 
-echo "==> Enabling SSH server (sshd)..."
+set -euo pipefail
 
-echo "    Starting sshd service..."
-systemctl start sshd.service
+if ! command -v pacman >/dev/null 2>&1; then
+    echo "This script configures an SSH server on Arch Linux."
+    exit 1
+fi
 
-echo "    Enabling sshd on boot..."
-systemctl enable sshd.service
+echo "==> Installing OpenSSH..."
+sudo pacman -S --needed openssh
 
-echo "==> Done! SSH server is running and enabled."
+echo "==> Enabling and starting the SSH server..."
+sudo systemctl enable --now sshd.service
+
+echo "==> Done. Connect from your Mac with: ssh <user>@<arch-ip-or-hostname>"


### PR DESCRIPTION
## Summary by Sourcery

Automate Arch Linux SSH server configuration and provide commands for managing the globally installed `inc` tool.

Enhancements:
- Configure Arch Linux SSH server setup to install OpenSSH and enable and start the service automatically.
- Add Justfile commands for installing, checking, updating the PATH for, and uninstalling the global editable `inc` tool.