### PR TITLE
Improve inc defaults and interactive run

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -58,6 +58,7 @@ ssh:
 docs:
     uv run jupyter-book build docs
 
-# Default target
+# Show available recipes by default
+[default]
 default:
-    install
+    @just --list

--- a/Justfile
+++ b/Justfile
@@ -7,27 +7,11 @@ install:
     uv venv --python 3.12
     uv sync --extra docs --extra dev
 
-dev:
+all:
     uv sync --extra dev --extra docs
 
 # Install the inc command globally while keeping this checkout editable
-tool-install:
-    uv tool install --editable . --python 3.12 --force
-
-# Verify the globally installed command works outside this repository
-tool-check:
-    cd /tmp && inc --help && inc ls
-
-# Add uv's executable directory to the shell PATH
-tool-path:
-    uv tool update-shell
-
-# Remove the globally installed inc command
-tool-uninstall:
-    uv tool uninstall inc
-
-# Install the inc command globally while keeping this checkout editable
-tool-install:
+dev:
     uv tool install --editable . --python 3.12 --force
 
 # Verify the globally installed command works outside this repository

--- a/inc/app.py
+++ b/inc/app.py
@@ -11,7 +11,7 @@ from .apps import apps_app, complete_app, doctor, load_catalog
 from .apps import install as install_apps
 from .config import PATH
 
-app = typer.Typer()
+app = typer.Typer(no_args_is_help=True)
 app.add_typer(apps_app, name="apps")
 app.command()(doctor)
 
@@ -29,6 +29,41 @@ def complete_script(incomplete: str) -> list[str]:
     )
     matches = scripts | set(complete_app(incomplete))
     return sorted(name for name in matches if name.startswith(incomplete))
+
+
+def run_targets() -> list[str]:
+    """Return all scripts and applications available to ``inc run``."""
+    bash_dir = PATH.bash
+    scripts = (
+        {
+            str(script.relative_to(bash_dir)).removesuffix(".sh")
+            for script in bash_dir.rglob("*.sh")
+        }
+        if bash_dir.exists()
+        else set()
+    )
+    return sorted(scripts | set(load_catalog().apps))
+
+
+def select_run_target() -> str | None:
+    """Select a run target with fzf, returning ``None`` when cancelled."""
+    try:
+        result = subprocess.run(
+            ["fzf", "--prompt", "inc run> "],
+            input="\n".join(run_targets()),
+            text=True,
+            stdout=subprocess.PIPE,
+            check=False,
+        )
+    except FileNotFoundError:
+        typer.echo(
+            "fzf is required for interactive selection. Install it with 'inc run fzf'."
+        )
+        raise typer.Exit(1) from None
+
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
 
 
 @app.command()
@@ -208,8 +243,8 @@ def ls(
 
 @app.command()
 def run(
-    script: str = typer.Argument(
-        ...,
+    script: str | None = typer.Argument(
+        None,
         help="Script or catalog application name. Use / for script subdirectories.",
         autocompletion=complete_script,
     ),
@@ -221,6 +256,11 @@ def run(
     ),
 ):
     """Run a bash script or install a catalog application."""
+    if script is None:
+        script = select_run_target()
+        if script is None:
+            return
+
     bash_dir = PATH.bash
     script_path = bash_dir / f"{script}.sh"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import importlib
 from types import SimpleNamespace
 
 from typer.testing import CliRunner
@@ -24,6 +25,14 @@ def test_ls():
     assert "  gh" in result.stdout
 
 
+def test_no_arguments_show_help():
+    result = runner.invoke(app, [])
+
+    assert "Usage:" in result.stdout
+    assert "Commands" in result.stdout
+    assert "run" in result.stdout
+
+
 def test_ls_recursive():
     result = runner.invoke(app, ["ls", "-r"])
     assert result.exit_code == 0
@@ -46,6 +55,28 @@ def test_run_dry_run():
     result = runner.invoke(app, ["run", "--dry-run", "brew"])
     assert result.exit_code == 0
     assert "Would execute" in result.stdout
+
+
+def test_run_without_target_uses_selector(monkeypatch):
+    app_module = importlib.import_module("inc.app")
+    monkeypatch.setattr(app_module, "select_run_target", lambda: "brew")
+
+    result = runner.invoke(app, ["run", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "Would execute" in result.stdout
+
+
+def test_fzf_selector_returns_selected_target(monkeypatch):
+    app_module = importlib.import_module("inc.app")
+
+    monkeypatch.setattr(
+        app_module.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="brew\n"),
+    )
+
+    assert app_module.select_run_target() == "brew"
 
 
 def test_run_missing_script():


### PR DESCRIPTION
## Summary
- make `just dev` install the editable `inc` tool
- remove duplicate tool recipes that prevented Justfile parsing
- show available recipes when running plain `just`
- show CLI help when running bare `inc`
- open an `fzf` selector when running `inc run` without a target

## Verification
- `just`
- `just dev`
- `just tool-check`
- `uv run pytest -q`
- `uv run ruff check inc/app.py tests/test_cli.py`
- `inc`
- `git diff --check`

## Summary by Sourcery

Improve default command behavior and interactive execution for `just` and `inc`.

New Features:
- Enable interactive selection of a run target when `inc run` is invoked without one.
- Display CLI help when `inc` is run without arguments.

Bug Fixes:
- Remove duplicate Justfile recipes that prevented the file from parsing correctly.

Enhancements:
- Show available Just recipes when running plain `just`.
- Make `just dev` install the editable `inc` tool.

Tests:
- Add coverage for bare CLI help, interactive run selection, and fzf result handling.